### PR TITLE
fix: Update prettier config & rename changeset check

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -1,4 +1,4 @@
-name: Validate Changeset Format
+name: Changeset
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   validate-changeset:
-    name: Validate Changeset Format
+    name: Validate Format
     runs-on: ubuntu-latest
 
     steps:

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,3 +1,3 @@
 {
-  "./**/*": ["prettier --write \"**/*.{js,jsx,mjs,ts,tsx,css,scss,md,json}\""]
+  "**/*.{js,jsx,mjs,ts,tsx,css,scss,md,json}": ["prettier --write"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,3 @@
-.changeset/
-.husky/
-public/
-.env
-.env.*
+dist/
+coverage/
+.next/


### PR DESCRIPTION
This PR updates Prettier and Lint-Staged configurations and renames the Changeset check workflow.

Major Changes:

- Updated Prettier configuration for formatting rules
- Refined Lint-Staged settings to check only specified file types
- Renamed the Changeset validation workflow